### PR TITLE
Don't default to "refresh: True" on package installation

### DIFF
--- a/zypper/packages.sls
+++ b/zypper/packages.sls
@@ -6,8 +6,6 @@ zypper_pkg_{{ package }}:
     - name: {{ package }}
     {% if 'refresh' in data %}
     - refresh: {{ data.refresh }}
-    {% else %}
-    - refresh: True
     {% endif %}
     {% if 'fromrepo' in data %}
     - fromrepo: {{ data.fromrepo }}


### PR DESCRIPTION
With "refresh: True", the repos will be refreshed for *every*
pkg.installed, which causes a terrible slowdown (in my tests, 9 seconds
for every package).

The refresh is already handled on the repo level, and pkg.installed
doesn't really need the refresh (it's not pkg.latest ;-) therefore drop
the default "refresh: True" to avoid lots of superfluous refreshs